### PR TITLE
chore: bump Go version to 1.25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM docker.io/library/golang:1.24.5-alpine AS builder
+FROM docker.io/library/golang:1.25.0-alpine AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Moulick/ingress-whitelister
 
-go 1.24.5
+go 1.25
 
 require (
 	github.com/cloudflare/cloudflare-go v0.115.0


### PR DESCRIPTION
## Summary
- use Go 1.25 module version
- build image from golang:1.25.0-alpine

## Testing
- `go test ./...` *(fails: Get "https://proxy.golang.org/golang.org/toolchain/@v/v0.0.1-go1.25.0.linux-amd64.zip": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68b36739bca483238a975d0a526e9f11